### PR TITLE
docs: replace manual clone with git subtree for LAD installation

### DIFF
--- a/LAD_RECIPE.md
+++ b/LAD_RECIPE.md
@@ -72,11 +72,14 @@ Import the complete `.lad/` directory into any target project once on main.
 
 ### 2.1 Quick Setup
 1. **Install Claude Code**: Follow [Claude Code installation guide](https://docs.anthropic.com/en/docs/claude-code)
-2. **Import LAD framework**:
+2. **Import LAD framework** (using git subtree):
    ```bash
-   git clone --depth 1 https://github.com/chrisfoulon/LAD tmp \
-     && rm -rf tmp/.git && mv tmp .lad \
-     && git add .lad && git commit -m "feat: add LAD framework"
+   git subtree add --prefix .lad https://github.com/chrisfoulon/LAD main --squash
+   ```
+
+   To update the framework later:
+   ```bash
+   git subtree pull --prefix .lad https://github.com/chrisfoulon/LAD main --squash
    ```
 3. **Create feature branch**: `git checkout -b feat/<slug>`
 
@@ -224,13 +227,16 @@ Import the complete `.lad/` directory into any target project once on main.
 ### 3.1 Quick‑Setup Checklist
 
 1. Enable **Copilot Chat + Agent Mode** in VS Code.
-2. **Import LAD kit once on main** (one-time setup):
+2. **Import LAD kit once on main** (using git subtree):
    ```bash
-   git clone --depth 1 https://github.com/chrisfoulon/LAD tmp \
-     && rm -rf tmp/.git \
-     && mv tmp .lad \
-     && git add .lad && git commit -m "feat: add LAD framework"
-   ```   * **Initialize coverage**: if `.coveragerc` is missing, scaffold it as above (branch=True, dynamic_context=test_function, omit `.lad/*`, show_missing=True, HTML dir `coverage_html`), then **manually** run:
+   git subtree add --prefix .lad https://github.com/chrisfoulon/LAD main --squash
+   ```
+
+   To update the framework later:
+   ```bash
+   git subtree pull --prefix .lad https://github.com/chrisfoulon/LAD main --squash
+   ```
+   * **Initialize coverage**: if `.coveragerc` is missing, scaffold it as above (branch=True, dynamic_context=test_function, omit `.lad/*`, show_missing=True, HTML dir `coverage_html`), then **manually** run:
      ```bash
      coverage run -m pytest [test_files] -q && coverage html
      ```

--- a/README.md
+++ b/README.md
@@ -30,14 +30,15 @@ LAD supports two autonomous workflows optimized for different development enviro
 **Multi-phase autonomous workflow for command-line development**
 
 ```bash
-# Quick Setup
-git clone --depth 1 https://github.com/chrisfoulon/LAD tmp \
-  && rm -rf tmp/.git && mv tmp .lad \
-  && git add .lad && git commit -m "feat: add LAD framework"
+# Quick Setup (using git subtree)
+git subtree add --prefix .lad https://github.com/chrisfoulon/LAD main --squash
 
 # Feature Development
 git checkout -b feat/my-feature
 # Tell Claude Code: "Use LAD framework to implement [feature description]"
+
+# Update LAD framework (when needed)
+git subtree pull --prefix .lad https://github.com/chrisfoulon/LAD main --squash
 ```
 
 **Example: Starting a new feature**
@@ -55,7 +56,7 @@ Claude: I'll use the LAD framework to implement user authentication. Let me star
 **⚠️ Requires Copilot Agent Mode - standard Copilot Chat alone will not work with LAD**
 
 ```bash
-# Same LAD import as above
+# Same LAD import as above (git subtree add)
 git checkout -b feat/my-feature
 # Tell Copilot Agent: "Use LAD framework to implement [feature description]"
 ```


### PR DESCRIPTION
Improved installation instructions to use `git subtree` instead of manual clone-and-copy workflow.

Benefits:
- Cleaner workflow (single command vs multiple)
- Built-in update mechanism with `git subtree pull`
- No need to manually manage .git directory removal
- History tracking with --squash option

Updated in both README.md and LAD_RECIPE.md for consistency across Claude Code and Copilot workflows.

PS I am yet to try LAD, but I did verify that this works ;-)